### PR TITLE
Add peer option to force RPKI valids

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ type Peer struct {
 
 	FilterIRR                  *bool `yaml:"filter-irr" description:"Should IRR filtering be applied?" default:"false"`
 	FilterRPKI                 *bool `yaml:"filter-rpki" description:"Should RPKI invalids be rejected?" default:"true"`
+  StrictRPKI                 *bool `yaml:"strict-rpki" description:"Should only RPKI valids be accepted?" default:"false"`
 	FilterMaxPrefix            *bool `yaml:"filter-max-prefix" description:"Should max prefix filtering be applied?" default:"true"`
 	FilterBogonRoutes          *bool `yaml:"filter-bogon-routes" description:"Should bogon prefixes be rejected?" default:"true"`
 	FilterBogonASNs            *bool `yaml:"filter-bogon-asns" description:"Should paths containing a bogon ASN be rejected?" default:"true"`

--- a/internal/embed/templates/global.tmpl
+++ b/internal/embed/templates/global.tmpl
@@ -321,6 +321,18 @@ function reject_rpki_invalid() {
   {{ end }}
 }
 
+function force_rpki_strict() {
+  {{ if .RPKIEnable }}
+  if (net.type = NET_IP4) then {
+    if (roa_check(rpki6, net, bgp_path.last_nonaggregated) != ROA_VALID) then _reject("RPKI != ROA_VALID");
+  }
+
+  if (net.type = NET_IP6) then {
+    if (roa_check(rpki4, net, bgp_path.last_nonaggregated) != ROA_VALID) then _reject("RPKI != ROA_VALID");
+  }
+  {{ end }}
+}
+
 function reject_out_of_bounds_routes() {
   if (net.type = NET_IP4) then {
     if (net.len > 24 || net.len < 8) then _reject("out of bounds (24 > len > 8)");

--- a/internal/embed/templates/peer.tmpl
+++ b/internal/embed/templates/peer.tmpl
@@ -57,6 +57,7 @@ protocol bgp {{ UniqueProtocolName $peer.ProtocolName $af }} {
             {{ if BoolDeref $peer.FilterBogonASNs }}reject_bogon_asns();{{ end }}
             {{ if BoolDeref $peer.FilterPrefixLength }}reject_out_of_bounds_routes();{{ end }}
             {{ if BoolDeref $peer.FilterRPKI }}reject_rpki_invalid();{{ end }}
+            {{ if BoolDeref $peer.StrictRPKI }}force_rpki_strict();{{ end }}
             {{ if BoolDeref $peer.FilterNeverViaRouteServers }}reject_never_via_route_servers();{{ end }}
             {{ if BoolDeref $peer.EnforceFirstAS }}enforce_first_as({{ $peer.ASN }});{{ end }}
             {{ if BoolDeref $peer.EnforcePeerNexthop }}enforce_peer_nexthop({{ $neighbor }});{{ end }}


### PR DESCRIPTION
A dicussion in networking-ix brought up the fact this feature should probably exist to allow for better filtering of downstreams. I hope I didn't forget anything required