### PR TITLE
Add new option for exporting all routes

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -104,6 +104,7 @@ sidebar_position: 3
 | prefixes | []string |  |  | Prefixes to accept |
 | announce-default | bool | false |  | Should a default route be exported to this peer? |
 | announce-originated | bool | true |  | Should locally originated routes be announced to this peer? |
+| announce-all | bool | false |  | Should all routes be exported to this peer? |
 | session-global | string |  |  | Configuration to add to each session before any defined BGP protocols |
 | pre-import | string |  |  | Configuration to add at the beginning of the import filter |
 | pre-export | string |  |  | Configuration to add at the beginning of the export filter |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,7 +91,7 @@ type Peer struct {
 	// Export options
 	AnnounceDefault    *bool `yaml:"announce-default" description:"Should a default route be exported to this peer?" default:"false"`
 	AnnounceOriginated *bool `yaml:"announce-originated" description:"Should locally originated routes be announced to this peer?" default:"true"`
-	AnnounceAll        *bool `yaml:"announce-all" description:"Should exporting of all routes be enabled for this peer?" default:"false"`
+	AnnounceAll        *bool `yaml:"announce-all" description:"Should all routes be exported to this peer?" default:"false"`
 
 	// Custom daemon configuration
 	SessionGlobal  *string `yaml:"session-global" description:"Configuration to add to each session before any defined BGP protocols" default:"-"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type Peer struct {
 	// Export options
 	AnnounceDefault    *bool `yaml:"announce-default" description:"Should a default route be exported to this peer?" default:"false"`
 	AnnounceOriginated *bool `yaml:"announce-originated" description:"Should locally originated routes be announced to this peer?" default:"true"`
+	AnnounceAll        *bool `yaml:"announce-all" description:"Should exporting of all routes be enabled for this peer?" default:"false"`
 
 	// Custom daemon configuration
 	SessionGlobal  *string `yaml:"session-global" description:"Configuration to add to each session before any defined BGP protocols" default:"-"`

--- a/internal/embed/templates/peer.tmpl
+++ b/internal/embed/templates/peer.tmpl
@@ -142,8 +142,11 @@ protocol bgp {{ UniqueProtocolName $peer.ProtocolName $af }} {
             {{ end }}
 
             {{ StrDeref $peer.PreExportFinal }}
-
+            {{ if BoolDeref $peer.AnnounceAll }}
+            accept;
+            {{ else }}
             reject;
+            {{ end }}
         };
     };
     {{ end }}


### PR DESCRIPTION
I found that there's currently not a way to export all of the routes to an peer which is useful in iBGP sessions.