### PR TITLE
feat: add PeeringDB API Key support

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -64,6 +64,7 @@ var generateCmd = &cobra.Command{
 		}
 		log.Debugln("Finished loading config")
 
+		peeringdb.InitAPIKey(c.PeeringDBAPIKey)
 		// Run NVRS query
 		if c.QueryNVRS {
 			var err error

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -64,11 +64,10 @@ var generateCmd = &cobra.Command{
 		}
 		log.Debugln("Finished loading config")
 
-		peeringdb.InitAPIKey(c.PeeringDBAPIKey)
 		// Run NVRS query
 		if c.QueryNVRS {
 			var err error
-			c.NVRSASNs, err = peeringdb.NeverViaRouteServers(c.PeeringDBQueryTimeout)
+			c.NVRSASNs, err = peeringdb.NeverViaRouteServers(c.PeeringDBQueryTimeout, c.PeeringDBAPIKey)
 			if err != nil {
 				log.Fatalf("PeeringDB NVRS query: %s", err)
 			}
@@ -128,7 +127,7 @@ var generateCmd = &cobra.Command{
 			if *peerData.AutoImportLimits || *peerData.AutoASSet {
 				log.Debugf("[%s] has auto-import-limits or auto-as-set, querying PeeringDB", peerName)
 
-				peeringdb.Update(peerData, c.PeeringDBQueryTimeout)
+				peeringdb.Update(peerData, c.PeeringDBQueryTimeout, c.PeeringDBAPIKey)
 			} // end peeringdb query enabled
 
 			// Build IRR prefix sets

--- a/cmd/match.go
+++ b/cmd/match.go
@@ -27,20 +27,22 @@ var matchCmd = &cobra.Command{
 	Use:   "match ASN",
 	Short: "Find common IXPs for a given ASN",
 	Run: func(cmd *cobra.Command, args []string) {
+
+		// Load the config file from config file
+		log.Debugf("Loading config from %s", configFile)
+		configFile, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			log.Fatal("Reading config file: " + err.Error())
+		}
+		c, err := process.Load(configFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Debugln("Finished loading config")
+
 		var peeringDbTimeout uint
 		peeringDbTimeout = 10
 		if matchLocalASN == 0 {
-			// Load the config file from config file
-			log.Debugf("Loading config from %s", configFile)
-			configFile, err := ioutil.ReadFile(configFile)
-			if err != nil {
-				log.Fatal("Reading config file: " + err.Error())
-			}
-			c, err := process.Load(configFile)
-			if err != nil {
-				log.Fatal(err)
-			}
-			log.Debugln("Finished loading config")
 			matchLocalASN = uint(c.ASN)
 			peeringDbTimeout = c.PeeringDBQueryTimeout
 		}
@@ -54,6 +56,6 @@ var matchCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		fmt.Println(match.CommonIXs(matchLocalASN, uint(peerASN), yamlFormat, peeringDbTimeout))
+		fmt.Println(match.CommonIXs(matchLocalASN, uint(peerASN), yamlFormat, peeringDbTimeout, c.PeeringDBAPIKey))
 	},
 }

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -70,7 +70,7 @@ func peeringDbIxLans(asn uint, peeringDbQueryTimeout uint) ([]peeringDbIxLanData
 }
 
 // CommonIXs gets common IXPs from PeeringDB
-func CommonIXs(a uint, b uint, yamlFormat bool, queryTimeout uint) string {
+func CommonIXs(a uint, b uint, yamlFormat bool, queryTimeout uint, apiKey string) string {
 	networkA, err := peeringDbIxLans(a, queryTimeout)
 	if err != nil {
 		log.Fatalf("AS%d: %v", a, err)
@@ -80,7 +80,7 @@ func CommonIXs(a uint, b uint, yamlFormat bool, queryTimeout uint) string {
 		log.Fatalf("AS%d: %v", a, err)
 	}
 
-	networkBInfo, err := peeringdb.NetworkInfo(b, queryTimeout)
+	networkBInfo, err := peeringdb.NetworkInfo(b, queryTimeout, apiKey)
 	if err != nil {
 		log.Fatalf("AS%d: %v", b, err)
 	}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -3,5 +3,5 @@ package match
 import "testing"
 
 func TestCommonIXs(t *testing.T) {
-	CommonIXs(34553, 13335, false, 10)
+	CommonIXs(34553, 13335, false, 10, "")
 }

--- a/internal/peeringdb/peeringdb.go
+++ b/internal/peeringdb/peeringdb.go
@@ -28,10 +28,23 @@ type Data struct {
 	ImportLimit6 int    `json:"info_prefixes6"`
 }
 
+var apiKey = ""
+
+func InitAPIKey(key string) {
+	if key != "" {
+		apiKey = key
+	}
+}
+
 // NetworkInfo returns PeeringDB for an ASN
 func NetworkInfo(asn uint, queryTimeout uint) (*Data, error) {
 	httpClient := http.Client{Timeout: time.Second * time.Duration(queryTimeout)}
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://peeringdb.com/api/net?asn=%d", asn), nil)
+
+	if apiKey != "" {
+		req.Header.Add("AUTHORIZATION", fmt.Sprintf("Api-Key %s", apiKey))
+	}
+
 	if err != nil {
 		return nil, errors.New("PeeringDB GET (This peer might not have a PeeringDB page): " + err.Error())
 	}

--- a/internal/peeringdb/peeringdb_test.go
+++ b/internal/peeringdb/peeringdb_test.go
@@ -26,7 +26,7 @@ func TestPeeringDbQuery(t *testing.T) {
 		{65530, "RIPE::RS-KROOT RIPE::RS-KROOT-V6", "RIPE NCC K-Root Operations", 5, 5, true}, // Private ASN, no PeeringDB page
 	}
 	for _, tc := range testCases {
-		pDbData, err := NetworkInfo(uint(tc.asn), peeringDbQueryTimeout)
+		pDbData, err := NetworkInfo(uint(tc.asn), peeringDbQueryTimeout, "")
 		if err != nil && !tc.shouldError {
 			t.Error(err)
 		}
@@ -57,7 +57,7 @@ func TestPeeringDbQuery(t *testing.T) {
 }
 
 func TestPeeringDbNoPage(t *testing.T) {
-	_, err := NetworkInfo(65530, peeringDbQueryTimeout)
+	_, err := NetworkInfo(65530, peeringDbQueryTimeout, "")
 	if err == nil || !strings.Contains(err.Error(), "doesn't have a PeeringDB page") {
 		t.Errorf("expected PeeringDB page not exist error, got %v", err)
 	}
@@ -78,12 +78,12 @@ func TestPeeringDbQueryAndModify(t *testing.T) {
 			AutoASSet:        util.BoolPtr(tc.auto),
 			ImportLimit4:     util.IntPtr(0),
 			ImportLimit6:     util.IntPtr(0),
-		}, peeringDbQueryTimeout)
+		}, peeringDbQueryTimeout, "")
 	}
 }
 
 func TestPeeringNeverViaRouteServers(t *testing.T) {
-	asns, err := NeverViaRouteServers(peeringDbQueryTimeout)
+	asns, err := NeverViaRouteServers(peeringDbQueryTimeout, "")
 	assert.Nil(t, err)
 	assert.Greater(t, len(asns), 100)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,6 +182,7 @@ type Optimizer struct {
 // Config stores the global configuration
 type Config struct {
 	PeeringDBQueryTimeout uint   `yaml:"peeringdb-query-timeout" description:"PeeringDB query timeout in seconds" default:"10"`
+	PeeringDBAPIKey       string `yaml:"peeringdb-api-key" description:"PeeringDB API key"`
 	IRRQueryTimeout       uint   `yaml:"irr-query-timeout" description:"IRR query timeout in seconds" default:"30"`
 	BIRDDirectory         string `yaml:"bird-directory" description:"Directory to store BIRD configs" default:"/etc/bird/"`
 	BIRDBinary            string `yaml:"bird-binary" description:"Path to BIRD binary" default:"/usr/sbin/bird"`


### PR DESCRIPTION
Solve PeeringDB 429 Too Many Requests issue.
PeeringDB server return:
```
{"message": "Request was throttled. Expected available in 59 minutes. Authenticate for less restrictions. For more information: https://docs.peeringdb.com/howto/api_keys/", "meta": {"error": "Too Many Requests"}}
```

Add a new section in the config YAML file.
`peeringdb-api-key: ""`
