### PR TITLE
bugfix

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -418,7 +418,7 @@ func Load(configBlob []byte) (*config.Config, error) {
 					if peerData.ImportStandardCommunities == nil {
 						peerData.ImportStandardCommunities = &[]string{}
 					}
-					*peerData.ImportStandardCommunities = append(*peerData.ImportStandardCommunities, community)
+					*peerData.ImportStandardCommunities = append(*peerData.ImportStandardCommunities, strings.ReplaceAll(community, ":", ","))
 				} else if communityType == "large" {
 					if peerData.ImportLargeCommunities == nil {
 						peerData.ImportLargeCommunities = &[]string{}


### PR DESCRIPTION
Replacing the delimiter is also required for standard communties. Otherwise the import and export of prefixes will not work:

```
Not working:
            bgp_community.add((49697:2200));
            bgp_large_community.add((49697,0,2200));
```


```
Working:
            bgp_community.add((49697,2200));
            bgp_large_community.add((49697,0,2200));
```