### PR TITLE
Bugfix: Copy manual*.conf to cache dir

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -635,9 +635,19 @@ func Run(configFilename, lockFile, version string, noConfigure, dryRun, withdraw
 	}
 	log.Debug("Finished writing global config file")
 
+	// Remove old manual configs
+	if err := util.RemoveFileGlob(path.Join(c.CacheDirectory, "manual*.conf")); err != nil {
+		log.Fatalf("Removing old manual config files: %v", err)
+	}
+
+	// Copying manual configs
+	if err := util.CopyFileGlob(path.Join(c.BIRDDirectory, "manual*.conf"), c.CacheDirectory); err != nil {
+		log.Fatalf("Copying manual config files: %v", err)
+	}
+
 	// Remove old peer-specific configs
 	if err := util.RemoveFileGlob(path.Join(c.CacheDirectory, "AS*.conf")); err != nil {
-		log.Fatalf("Removing old config files: %v", err)
+		log.Fatalf("Removing old peer config files: %v", err)
 	}
 
 	// Print global config


### PR DESCRIPTION
Hello,
I have created a `manual-communities.conf` file in the BIRD directory with function like:
```
function action_communities() {
  if ((206016,0,999) ~ bgp_large_community) then _reject("By action community");
}
```
And then tried to use this function in `pre-export` attribute. But got an error when executing `pathvector generate`:
```
INFO[0000] Starting Pathvector devel                    
FATA[0000] BIRD: BIRD validation error:
        export filter {
            action_communities();
            ^ syntax error, unexpected CF_SYM_UNDEFINED
            remove_private_asns();
```
If I add this function directly to config `ASxxx_NAME_v6.conf` and run `birdc configure check` I got answer `Configuration OK`

After some investigating I found that pathvector creates cache dir and check config files from this dir BUT it don't include/copy `manual*.conf` files from original BIRD directory. Therefore, pathvector considers that the function from the `manual-communities.conf` file does not exist
So, I wrote this patch which copy all `manual*.conf` from BIRD directory to cache directory and this solve the problem.