### PR TITLE
Fix origin-communities description + add local-communities

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -224,7 +224,8 @@ type Config struct {
 	WebUIFile             string   `yaml:"web-ui-file" description:"File to write web UI to (disabled if empty)" default:""`
 	LogFile               string   `yaml:"log-file" description:"Log file location" default:"syslog"`
 	GlobalConfig          string   `yaml:"global-config" description:"Global BIRD configuration" default:""`
-	OriginCommunities     []string `yaml:"origin-communities" description:"List of communities to add to locally originated routes" default:""`
+	OriginCommunities     []string `yaml:"origin-communities" description:"List of communities to accept as locally originated routes" default:""`
+	LocalCommunities      []string `yaml:"local-communities" description:"List of communities to add to locally originated prefixes" default:""`
 
 	Hostname string `yaml:"hostname" description:"Router hostname (default system hostname)" default:""`
 
@@ -264,6 +265,8 @@ type Config struct {
 	NVRSASNs                  []uint32 `yaml:"-" description:"-"`
 	OriginStandardCommunities []string `yaml:"-" description:"-"`
 	OriginLargeCommunities    []string `yaml:"-" description:"-"`
+	LocalStandardCommunities  []string `yaml:"-" description:"-"`
+	LocalLargeCommunities     []string `yaml:"-" description:"-"`
 }
 
 // Init initializes a Config with embedded structs prior to calling config.Default

--- a/pkg/embed/templates/global.tmpl
+++ b/pkg/embed/templates/global.tmpl
@@ -390,12 +390,24 @@ function accept_local() {
 
   {{ if .Prefixes4 -}}
   if (net ~ LOCALv4) then {
+    {{ range $i, $community := StringSliceIter .LocalStandardCommunities }}
+    bgp_community.add(({{ $community }}));
+    {{ end }}
+    {{ range $i, $community := StringSliceIter .LocalLargeCommunities }}
+    bgp_large_community.add(({{ $community }}));
+    {{ end }}
     accept;
   }
   {{- end }}
 
   {{ if .Prefixes6 -}}
   if (net ~ LOCALv6) then {
+    {{ range $i, $community := StringSliceIter .LocalStandardCommunities }}
+    bgp_community.add(({{ $community }}));
+    {{ end }}
+    {{ range $i, $community := StringSliceIter .LocalLargeCommunities }}
+    bgp_large_community.add(({{ $community }}));
+    {{ end }}
     accept;
   }
   {{- end }}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -300,7 +300,7 @@ func Load(configBlob []byte) (*config.Config, error) {
 				if c.OriginStandardCommunities == nil {
 					c.OriginStandardCommunities = []string{}
 				}
-				c.OriginStandardCommunities = append(c.OriginStandardCommunities, community)
+				c.OriginStandardCommunities = append(c.OriginStandardCommunities, strings.ReplaceAll(community, ":", ","))
 			} else if communityType == "large" {
 				if c.OriginLargeCommunities == nil {
 					c.OriginLargeCommunities = []string{}
@@ -308,6 +308,25 @@ func Load(configBlob []byte) (*config.Config, error) {
 				c.OriginLargeCommunities = append(c.OriginLargeCommunities, strings.ReplaceAll(community, ":", ","))
 			} else {
 				return nil, errors.New("Invalid origin community: " + community)
+			}
+		}
+	}
+
+	if c.LocalCommunities != nil {
+		for _, community := range c.LocalCommunities {
+			communityType := categorizeCommunity(community)
+			if communityType == "standard" {
+				if c.LocalStandardCommunities == nil {
+					c.LocalStandardCommunities = []string{}
+				}
+				c.LocalStandardCommunities = append(c.LocalStandardCommunities, strings.ReplaceAll(community, ":", ","))
+			} else if communityType == "large" {
+				if c.LocalLargeCommunities == nil {
+					c.LocalLargeCommunities = []string{}
+				}
+				c.LocalLargeCommunities = append(c.LocalLargeCommunities, strings.ReplaceAll(community, ":", ","))
+			} else {
+				return nil, errors.New("Invalid local community: " + community)
 			}
 		}
 	}

--- a/tests/generate-complex.yml
+++ b/tests/generate-complex.yml
@@ -12,6 +12,10 @@ origin-communities:
   - 34553:10
   - 34553:10:1
 
+local-communities:
+  - 65530:65530
+  - 65530:100:65530
+
 kernel:
   srd-communities:
     - 65530,1


### PR DESCRIPTION
Hello,
I found `origin-communities` option with description:

> List of communities to add to locally originated routes

But instead of **_adding communities_**, it **_accepts routes_** that have one of the listed communities. Сorrected description:

> List of communities to accept as locally originated routes

Also I added `local-communities` which fulfills the original `origin-communities` function