### PR TITLE
fix: make default-local-pref usable

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -249,7 +249,7 @@ func Load(configBlob []byte) (*config.Config, error) {
 			peerData.PreExportFinal = util.Ptr(templateReplacements(*peerData.PreExportFinal, peerData))
 		}
 
-		if peerData.DefaultLocalPref != nil && peerData.OptimizeInbound != nil {
+		if peerData.DefaultLocalPref != nil && util.Deref(peerData.OptimizeInbound) {
 			log.Fatalf("Both DefaultLocalPref and OptimizeInbound set, Pathvector cannot optimize this peer.")
 		}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -133,12 +133,18 @@ func RemoveFileGlob(glob string) error {
 
 // Pointer helpers used to write cleaner tests
 
+// Deref returns the value of a pointer
+func Deref[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}
+
 // StrDeref returns the value of a pointer to a string
 func StrDeref(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
+	return Deref(s)
 }
 
 func Ptr[T any](a T) *T {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -89,6 +89,10 @@ func TestPrintTable(t *testing.T) {
 }
 
 func TestUtilPtrDeref(t *testing.T) {
+	assert.Equal(t, true, Deref(Ptr(true)))
+	assert.Equal(t, false, Deref(Ptr(false)))
+	assert.Equal(t, false, Deref[bool](nil))
+
 	assert.Equal(t, "foo", StrDeref(Ptr("foo")))
 	assert.Equal(t, "", StrDeref(nil))
 }


### PR DESCRIPTION
Due to a logical error in `process.Load`, any peer with `default-local-pref` property set is resulting in error:

```text
FATA[0000] Both DefaultLocalPref and OptimizeInbound set, Pathvector cannot optimize this peer. 
```

This above error occurs even if `optimize-inbound` is not set.

This patch fixes this logical error and makes `default-local-pref` usable again.