### PR TITLE
Add missing provider role (BGP RFC 9234)

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -290,8 +290,8 @@ func Load(configBlob []byte) (*config.Config, error) {
 		// Validate RFC 9234 BGP role
 		if peerData.Role != nil {
 			peerData.Role = util.Ptr(strings.ReplaceAll(*peerData.Role, "-", "_"))
-			if *peerData.Role != "rs_server" && *peerData.Role != "rs_client" && *peerData.Role != "customer" && *peerData.Role != "peer" {
-				return nil, fmt.Errorf("[%s] Invalid BGP role: %s (must be one of rs-server, rs-client, customer, peer)", *peerData.Role, peerName)
+			if *peerData.Role != "provider" && peerData.Role != "rs_server" && *peerData.Role != "rs_client" && *peerData.Role != "customer" && *peerData.Role != "peer" {
+				return nil, fmt.Errorf("[%s] Invalid BGP role: %s (must be one of provider, rs-server, rs-client, customer, peer)", *peerData.Role, peerName)
 			}
 		}
 		requireRoles := peerData.RequireRoles != nil && *peerData.RequireRoles


### PR DESCRIPTION
As per BIRD 2.0 documentation:

Possible role-name values are: provider, rs_server, rs_client, customer and peer. Default: No local role assigned.

Source: https://bird.network.cz/?get_doc&v=20&f=bird-6.html#ss6.3