### PR TITLE
feat: Add peer settings for `next-hop-self-ebgp` and `next-hop-self-ibgp`

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -847,6 +847,22 @@ Should BGP next-hop-self be enabled?
 |------|---------|------------|
 | bool   | false      |          |
 
+### `next-hop-self-ebgp`
+
+Should BGP next-hop-self for eBGP be enabled?
+
+| Type | Default | Validation |
+|------|---------|------------|
+| bool   | false      |          |
+
+### `next-hop-self-ibgp`
+
+Should BGP next-hop-self for iBGP be enabled?
+
+| Type | Default | Validation |
+|------|---------|------------|
+| bool   | false      |          |
+
 ### `bfd`
 
 Should BFD be enabled?

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,8 @@ type Peer struct {
 	Passive                *bool     `yaml:"passive" description:"Should we listen passively?" default:"false"`
 	Direct                 *bool     `yaml:"direct" description:"Specify that the neighbor is directly connected" default:"false"`
 	NextHopSelf            *bool     `yaml:"next-hop-self" description:"Should BGP next-hop-self be enabled?" default:"false"`
+	NextHopSelfEBGP        *bool     `yaml:"next-hop-self-ebgp" description:"Should BGP next-hop-self for eBGP be enabled?" default:"false"`
+	NextHopSelfIBGP        *bool     `yaml:"next-hop-self-ibgp" description:"Should BGP next-hop-self for iBGP be enabled?" default:"false"`
 	BFD                    *bool     `yaml:"bfd" description:"Should BFD be enabled?" default:"false"`
 	Password               *string   `yaml:"password" description:"BGP MD5 password" default:"-"`
 	RSClient               *bool     `yaml:"rs-client" description:"Should this peer be a route server client?" default:"false"`

--- a/pkg/embed/templates/peer.tmpl
+++ b/pkg/embed/templates/peer.tmpl
@@ -77,6 +77,8 @@ protocol bgp {{ UniqueProtocolName $peer.ProtocolName $peerName $af $peer.ASN $p
         {{ end }}
 
         {{ if BoolDeref $peer.NextHopSelf }}next hop self;{{ end }}
+        {{ if BoolDeref $peer.NextHopSelfEBGP }}next hop self ebgp;{{ end }}
+        {{ if BoolDeref $peer.NextHopSelfIBGP }}next hop self ibgp;{{ end }}
         {{ if BoolDeref $peer.AddPathTx }}add paths tx;{{ end }}
         {{ if BoolDeref $peer.AddPathRx }}add paths rx;{{ end }}
         {{ if BoolDeref $peer.AdvertiseHostname }}advertise hostname on;{{ end }}

--- a/tests/generate-complex.yml
+++ b/tests/generate-complex.yml
@@ -122,3 +122,19 @@ peers:
       65510,20,30: 300
     tags:
       - ixp
+
+  Internal:
+    neighbors:
+    - 192.0.2.3
+    - 2001:db8::3
+    asn: 65530
+    announce-all: true
+    filter-irr: false
+    filter-rpki: false
+    filter-bogon-asns: false
+    filter-bogon-routes: false
+    filter-blocklist: false
+    filter-prefix-length: false
+    enforce-first-as: false
+    enforce-peer-nexthop: false
+    next-hop-self-ebgp: true


### PR DESCRIPTION
According to the Bird docs, `next hop self` has a few additional choices than just on/off:

> `next hop self switch|ibgp|ebgp`
> 
> Always advertise our own local address as a next hop, even in cases where the current Next Hop attribute should be used unchanged. This is sometimes used for routes propagated from EBGP to IBGP when IGP routing does not cover inter-AS links, therefore IP addreses of EBGP neighbors are not resolvable through IGP. Can be enabled for all routes, or just for routes received from IBGP / EBGP neighbors. Default: disabled.

This MR adds support for the `ibgp` and `ebgp` variants.