### PR TITLE
fix: add HE as new transit as

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var defaultTransitASNs = []uint32{
 	6762, // Seabone / Telecom Italia
 	6830, // Liberty Global
 	7018, // AT&T
+	6939, // Hurricane Electric LLC (ipv6 Tier 1)
 }
 
 var defaultBogons4 = []string{


### PR DESCRIPTION
As described in https://github.com/natesales/pathvector/issues/203, Huricane Electrics should be included as a Transit AS, as it is now firmly understood in the community as Tier 1 in the IPv6 area.