### PR TITLE
feature: Add gateway parameter in peers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,6 +141,7 @@ type Peer struct {
 	DisableAfterError      *bool     `yaml:"disable-after-error" description:"Disable peer after error" default:"false"`
 	PreferOlderRoutes      *bool     `yaml:"prefer-older-routes" description:"Prefer older routes instead of comparing router IDs (RFC 5004)" default:"false"`
 	IRRAcceptChildPrefixes *bool     `yaml:"irr-accept-child-prefixes" description:"Accept prefixes up to /24 and /48 from covering parent IRR objects" default:"false"`
+	Gateway                *string   `yaml:"gateway" description:"The mode in which the gateway is defined for received routes (direct|recursive)." default:"-"`
 
 	ImportCommunities    *[]string `yaml:"add-on-import" description:"List of communities to add to all imported routes" default:"-"`
 	ExportCommunities    *[]string `yaml:"add-on-export" description:"List of communities to add to all exported routes" default:"-"`

--- a/pkg/embed/templates/peer.tmpl
+++ b/pkg/embed/templates/peer.tmpl
@@ -83,6 +83,7 @@ protocol bgp {{ UniqueProtocolName $peer.ProtocolName $peerName $af $peer.ASN $p
         {{ if BoolDeref $peer.AddPathRx }}add paths rx;{{ end }}
         {{ if BoolDeref $peer.AdvertiseHostname }}advertise hostname on;{{ end }}
         {{ if BoolDeref $peer.DisableAfterError }}disable after error on;{{ end }}
+        {{ if StrDeref $peer.Gateway }}gateway "{{ StrDeref $peer.Gateway }}";{{ end }}
         import filter {
             {{ if $global.NoAccept }}reject; # no-accept: true{{ end }}
             {{ if (not (BoolDeref $peer.Import)) }}reject; # import: false{{ end }}


### PR DESCRIPTION
As described in https://github.com/natesales/pathvector/issues/197 , it should be possible to set the gateway mode in peers, in which the gateway is determined. 

The strings 'direct' or 'recursive' can be assigned to the gateway parameter.

Details to the "gateway" functionality are also described in the bird documentation: https://bird.network.cz/?get_doc&v=16&f=bird-6.html