### PR TITLE
Changed default IPv6 Import Limit to 300000

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1101,7 +1101,7 @@ Maximum number of IPv6 prefixes to import after filtering
 
 | Type | Default | Validation |
 |------|---------|------------|
-| int   | 200000      |          |
+| int   | 300000      |          |
 
 ### `import-limit-violation`
 

--- a/pkg/bird/bird_test.go
+++ b/pkg/bird/bird_test.go
@@ -112,7 +112,7 @@ static4    Static     master4    up     2023-03-15 19:18:50
     Preference:     100
     Input filter:   (unnamed)
     Output filter:  (unnamed)
-    Import limit:   200000
+    Import limit:   300000
       Action:       disable
     Routes:         176493 imported, 0 filtered, 2 exported, 175609 preferred
     Route change stats:     received   rejected   filtered    ignored   accepted
@@ -396,7 +396,7 @@ EXAMPLE_AS65522_v6 BGP        ---        up     2023-03-26 03:53:56  Established
    Preference:     100
    Input filter:   (unnamed)
    Output filter:  (unnamed)
-   Import limit:   200000
+   Import limit:   300000
 	 Action:       disable
    Routes:         176493 imported, 0 filtered, 2 exported, 175609 preferred
    Route change stats:     received   rejected   filtered    ignored   accepted

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -158,7 +158,7 @@ type Peer struct {
 	ASSet *string `yaml:"as-set" description:"Peer's as-set for filtering" default:"-"`
 
 	ImportLimit4          *int    `yaml:"import-limit4" description:"Maximum number of IPv4 prefixes to import after filtering" default:"1000000"`
-	ImportLimit6          *int    `yaml:"import-limit6" description:"Maximum number of IPv6 prefixes to import after filtering" default:"200000"`
+	ImportLimit6          *int    `yaml:"import-limit6" description:"Maximum number of IPv6 prefixes to import after filtering" default:"300000"`
 	ImportLimitTripAction *string `yaml:"import-limit-violation" description:"What action should be taken when the import limit is tripped?" default:"disable"`
 
 	ReceiveLimit4          *int    `yaml:"receive-limit4" description:"Maximum number of IPv4 prefixes to accept (including filtered routes, requires keep-filtered)" default:"-"`


### PR DESCRIPTION
Since the global IPv6 routes are already pass 200k by the year of 2024, continue of using the default configuration might cause upstream to be disconnected.

![image](https://github.com/natesales/pathvector/assets/5138409/ebd3b4e3-358c-40d2-a157-d72dce0f713f)
Therefore, increasing the default limit to 300k should be enough for a while.